### PR TITLE
Add FFMPEG support and config file

### DIFF
--- a/TKinter_ROI_Frames_Selector.cfg
+++ b/TKinter_ROI_Frames_Selector.cfg
@@ -1,0 +1,2 @@
+[SETTINGS]
+FFMPEGFileExtensions: [".mov", ".avi", ".mpg", ".mpeg", ".mp4", ".mkv", ".wmv"]


### PR DESCRIPTION
* Included support for FFMPEG file types. When reading from a video, the number of available frames is hard/expensive to calculate, which is why it is set to inf by default, indicating “stream mode”. To get the number of frames before having read them all, you can use the reader.count_frames() method.

* Non-FFMPEG file types now uses get_length to calculate the number of frames

* Config file included

